### PR TITLE
Fast Quantised Integer Logarithm (#288)

### DIFF
--- a/src/util/log2.hpp
+++ b/src/util/log2.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "util/types.hpp"
+#include <bit>
+#include <cassert>
+
+namespace Clockwork {
+
+[[nodiscard]] constexpr i64 log2i(i32 x) {
+    assert(x > 0);
+
+    int head = std::countl_zero(static_cast<u32>(x));
+    u32 rem  = static_cast<u32>(x) << (head + 1) >> 22;
+
+    u32 big   = static_cast<u32>(31 - head) * 1024;
+    u32 small = rem + (355 * rem * (1024 - rem)) / (1024 * 1024);
+
+    return static_cast<i64>(big + small);
+}
+
+}


### PR DESCRIPTION
We replace the use of `std::log` in the LMR formula for a speed improvement.

Constants adjusted for the new base, and divisors made powers of two.

Value of `355` was chosen to minimize error of result of `log2i`.

```
Test  | log2i
Elo   | 2.41 +- 1.85 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 50936 W: 12906 L: 12552 D: 25478
Penta | [796, 6144, 11284, 6398, 846]
```
https://clockworkopenbench.pythonanywhere.com/test/765/

Bench: 10951405