### PR TITLE
Fix aspiration window bounds going out of range (#323)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -262,6 +262,8 @@ Move Worker::iterative_deepening(const Position& root_position) {
         while (true) {
             int asp_window_depth = search_depth - fail_high_reduction;
 
+            alpha = std::max(-VALUE_INF, alpha);
+            beta  = std::min(VALUE_INF, beta);
             score = search<IS_MAIN, true>(root_position, &ss[SS_PADDING], alpha, beta,
                                           asp_window_depth, 0, false);
 


### PR DESCRIPTION
```
Test  | fix2
Elo   | -0.16 +- 1.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-4.50, 0.50]
Games | N: 41700 W: 9628 L: 9647 D: 22425
Penta | [361, 4662, 10790, 4709, 328]
```
https://clockworkopenbench.pythonanywhere.com/test/952/

Bench: 11910746